### PR TITLE
Copied in current production version from ztp.paxio.net:/etc/dhcp/dhc…

### DIFF
--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -18,13 +18,16 @@ group {
     option tftp-server-name "64.201.245.217";
     option log-servers 64.201.245.213,64.201.245.214;
     option ntp-servers 173.241.19.157,173.241.19.50;
+    option time-offset 0;
+    #option pcode "EST5EDT4,M3.2.0/02:00,M11.1.0/02:00";
+    #option tcode "America/New_York"
     option ZTP.transfer-mode "http";
 
     # Juniper-ex2300-c-12t
     class "juniper-ex2300-c-12" {
         match if ( option vendor-class-identifier ~~ "Juniper-ex2300");
         option ZTP.image-file-name "images/junos-arm-32-18.1R3.3.tgz";
-        option ZTP.config-file-name "default.conf";
+	option ZTP.config-file-name "default-ex2300.conf";
     }
 
     # Juniper-ex3300-24t
@@ -36,7 +39,7 @@ group {
     # Juniper-ex4300-32f
     class "Juniper-ex4300-32f" {
         match if (substring (option vendor-class-identifier,0,18) = "Juniper-ex4300-32f");
-        option ZTP.image-file-name "images/jinstall-ex-4300-17.3R3.10-signed.tgz";
+        option ZTP.image-file-name "images/jinstall-ex-4300-18.1R2.5-signed.tgz";
     }
 
     # Juniper-ex4600-40f
@@ -49,6 +52,19 @@ group {
     class "Juniper-acx5048" {
         match if (option vendor-class-identifier ~~ "Juniper-acx5048");
         option ZTP.image-file-name "images/jinstall-host-acx5k-17.2R2.8-signed.tgz";
+    }
+
+    # Icotera i6405-51 v2.2.1 firmware
+    class "Icotera-i6405-v2.2.1" {
+        match if ( substring (option host-name, 0, 5) = "i6400"); 
+        option bootfile-name "default.dat-2.2.1_to_2.5.0_generic_host";
+    }
+
+    # Icotera i6405-51 v2.5.0 firmware
+    class "Icotera-i6405-v2.5.0" {
+        #match if ( option host-name = “CPE-generic-icotera”);
+        match if option vendor-class-identifier ~~ "i6405-51";
+        option bootfile-name "default.dat";
     }
 
     subnet 64.201.245.0 netmask 255.255.255.0 { }


### PR DESCRIPTION
Copied in current production version from ztp.paxio.net:/etc/dhcp/dhcpd.conf.  This will make the github repository equal to what's in production *for that individual file*, assuming that server is the only place we're running this in production.